### PR TITLE
 Issue #128: Prevent the user from tampering with the blocker items

### DIFF
--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/state/SimulationButtonStateInterface.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/state/SimulationButtonStateInterface.java
@@ -1,0 +1,5 @@
+package com.groupesan.project.java.scrumsimulator.mainpackage.state;
+
+public interface SimulationButtonStateInterface {
+    void updateButtonVisibility(boolean isRunning);
+}

--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/state/SimulationStateManager.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/state/SimulationStateManager.java
@@ -28,23 +28,25 @@ public class SimulationStateManager {
     private JFrame frame;
     private JTextArea sprintDisplayArea;
     private static final SecureRandom secureRandom = new SecureRandom();
+    private SimulationButtonStateInterface buttonStateListener;
 
     /** Simulation State manager. Not running by default. */
     public SimulationStateManager() {
         this.running = false;
     }
 
-    /**
-     * Returns the current state of the simulation.
-     *
-     * @return boolean running
-     */
+   public void setButtonStateListener(SimulationButtonStateInterface listener) {
+        this.buttonStateListener = listener;
+    }
     public boolean isRunning() {
         return running;
     }
 
     public void setRunning(boolean running) {
         this.running = running;
+        if (buttonStateListener != null) {
+            buttonStateListener.updateButtonVisibility(running);
+        }
     }
 
     /** Method to set the simulation state to running. */
@@ -153,8 +155,7 @@ public class SimulationStateManager {
 
             @Override
             protected void done() {
-                running = false;
-                SimulationPanel.updateButtonVisibility();
+                setRunning(false);
             }
         };
 

--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/BlockersListPane.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/BlockersListPane.java
@@ -4,6 +4,7 @@ import com.groupesan.project.java.scrumsimulator.mainpackage.impl.SprintBlocker;
 import com.groupesan.project.java.scrumsimulator.mainpackage.impl.BlockerStore;
 import com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets.BaseComponent;
 import com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets.BlockerWidget;
+import com.groupesan.project.java.scrumsimulator.mainpackage.state.SimulationStateManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -14,9 +15,18 @@ public class BlockersListPane extends JFrame implements BaseComponent {
     private List<BlockerWidget> widgets = new ArrayList<>();
     private JPanel headerPanel;
     private JPanel blockersPanel;
+    private SimulationStateManager simStateManager;
 
     public BlockersListPane() {
         this.init();
+    }
+
+    public void setSimulationStateManager(SimulationStateManager simStateManager) {
+        this.simStateManager = simStateManager;
+        // Update existing widgets with the state manager
+        for (BlockerWidget widget : widgets) {
+            widget.setStateManager(simStateManager);
+        }
     }
 
     public void init() {
@@ -41,6 +51,15 @@ public class BlockersListPane extends JFrame implements BaseComponent {
 
         JButton newBlockerButton = new JButton("New Blocker");
         newBlockerButton.addActionListener(e -> {
+            if (simStateManager != null && simStateManager.isRunning()) {
+                JOptionPane.showMessageDialog(
+                    this,
+                    "Cannot create new blockers while the simulation is running",
+                    "Operation Not Allowed: Simulation Running",
+                    JOptionPane.ERROR_MESSAGE
+                );
+                return;
+            }
             NewBlockerForm form = new NewBlockerForm();
             form.setVisible(true);
 
@@ -49,7 +68,7 @@ public class BlockersListPane extends JFrame implements BaseComponent {
                     SprintBlocker blocker = form.getBlockerObject();
                     if (blocker != null) {
                         BlockerStore.getInstance().addBlocker(blocker);
-                        addBlockerWidget(new BlockerWidget(blocker));
+                        addBlockerWidget(new BlockerWidget(blocker, simStateManager));
                     }
                 }
             });
@@ -59,6 +78,15 @@ public class BlockersListPane extends JFrame implements BaseComponent {
 
         JButton blockerSolutionsButton = new JButton("Blocker Solutions");
         blockerSolutionsButton.addActionListener(e -> {
+            if (simStateManager != null && simStateManager.isRunning()) {
+                JOptionPane.showMessageDialog(
+                    this,
+                    "Cannot modify blocker solutions while the simulation is running",
+                    "Operation Not Allowed: Simulation Running",
+                    JOptionPane.ERROR_MESSAGE
+                );
+                return;
+            }
             BlockerSolutionsListPane blockerSolutionsPane = new BlockerSolutionsListPane();
             blockerSolutionsPane.addWindowListener(new java.awt.event.WindowAdapter() {
                 @Override
@@ -102,7 +130,7 @@ public class BlockersListPane extends JFrame implements BaseComponent {
 
     private void loadBlockers() {
         for (SprintBlocker blocker : BlockerStore.getInstance().getBlockers()) {
-            addBlockerWidget(new BlockerWidget(blocker));
+            addBlockerWidget(new BlockerWidget(blocker, simStateManager));
         }
     }
 

--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/DemoPane.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/DemoPane.java
@@ -3,6 +3,7 @@ package com.groupesan.project.java.scrumsimulator.mainpackage.ui.panels;
 import com.groupesan.project.java.scrumsimulator.mainpackage.core.Player;
 import com.groupesan.project.java.scrumsimulator.mainpackage.core.ScrumRole;
 import com.groupesan.project.java.scrumsimulator.mainpackage.core.Simulation;
+import com.groupesan.project.java.scrumsimulator.mainpackage.state.SimulationStateManager;
 import com.groupesan.project.java.scrumsimulator.mainpackage.ui.utils.WizardManager;
 import com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets.BaseComponent;
 import com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets.WizardHandler;
@@ -28,11 +29,14 @@ public class DemoPane extends JFrame implements BaseComponent {
     private SimulationPane simulationPane;
     private ModifySimulationPane modifySimulationPane;
     private SimulationUI simulationUserInterface;
+    private SimulationStateManager simulationStateManager;
+    private BlockersListPane blockersListPane;
     // private SimulationSwitchRolePane simulationSwitchRolePane;
     private VariantSimulationUI variantSimulationUI;
     // private SprintUIPane sprintUIPane;
 
     public DemoPane() {
+        this.simulationStateManager = new SimulationStateManager();
         this.init();
         player.doRegister();
     }
@@ -61,7 +65,7 @@ public class DemoPane extends JFrame implements BaseComponent {
                     }
                 });
 
-        SimulationPanel simulationPanel = new SimulationPanel();
+        SimulationPanel simulationPanel = new SimulationPanel(simulationStateManager);
         myJpanel.add(
                 simulationPanel,
                 new CustomConstraints(
@@ -242,8 +246,13 @@ public class DemoPane extends JFrame implements BaseComponent {
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        BlockersListPane blockersPane = new BlockersListPane();
-                        blockersPane.setVisible(true);
+                        if (blockersListPane == null || !blockersListPane.isDisplayable()) {
+                            blockersListPane = new BlockersListPane();
+                            blockersListPane.setSimulationStateManager(simulationStateManager);
+                            blockersListPane.setVisible(true);
+                        } else {
+                            blockersListPane.toFront();
+                        }
                     }
                 });
 

--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/SimulationPanel.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/SimulationPanel.java
@@ -1,22 +1,26 @@
 package com.groupesan.project.java.scrumsimulator.mainpackage.ui.panels;
 
-import com.groupesan.project.java.scrumsimulator.mainpackage.state.SimulationStateManager;
-import com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets.BaseComponent;
-
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import javax.swing.JPanel;
+
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 
-public class SimulationPanel extends JPanel implements BaseComponent {
+import com.groupesan.project.java.scrumsimulator.mainpackage.state.SimulationStateManager;
+import com.groupesan.project.java.scrumsimulator.mainpackage.state.SimulationButtonStateInterface;
+import com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets.BaseComponent;
 
-    private static final SimulationStateManager simulationStateManager  = new SimulationStateManager();
-    private static final JButton startSimulationButton  = new JButton("Start Simulation");;
-    private static final JButton stopSimulationButton = new JButton("Stop Simulation");
+public class SimulationPanel extends JPanel implements BaseComponent, SimulationButtonStateInterface {
+    private final SimulationStateManager simulationStateManager;
+    private final JButton startSimulationButton;
+    private final JButton stopSimulationButton;
 
-    /** Simulation Panel Initialization. */
-    public SimulationPanel() {
+    public SimulationPanel(SimulationStateManager simulationStateManager) {
+        this.simulationStateManager = simulationStateManager;
+        this.startSimulationButton = new JButton("Start Simulation");
+        this.stopSimulationButton = new JButton("Stop Simulation");
+        simulationStateManager.setButtonStateListener(this);
         this.init();
     }
 
@@ -26,15 +30,12 @@ public class SimulationPanel extends JPanel implements BaseComponent {
 
     @Override
     public void init() {
-
         stopSimulationButton.setVisible(false);
-
         startSimulationButton.addActionListener(
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
                         simulationStateManager.startSimulation();
-                        updateButtonVisibility();
                     }
                 });
 
@@ -44,7 +45,6 @@ public class SimulationPanel extends JPanel implements BaseComponent {
                     public void actionPerformed(ActionEvent e) {
                         simulationStateManager.stopSimulation();
                         JOptionPane.showMessageDialog(null, "Simulation stopped!");
-                        updateButtonVisibility();
                     }
                 });
 
@@ -52,14 +52,9 @@ public class SimulationPanel extends JPanel implements BaseComponent {
         add(stopSimulationButton);
     }
 
-    public static void updateButtonVisibility() {
-        // Show/hide buttons based on the simulation state
-        if (simulationStateManager.isRunning()) {
-            stopSimulationButton.setVisible(true);
-            startSimulationButton.setVisible(false);
-        } else {
-            stopSimulationButton.setVisible(false);
-            startSimulationButton.setVisible(true);
-        }
+    @Override
+    public void updateButtonVisibility(boolean isRunning) {
+        stopSimulationButton.setVisible(isRunning);
+        startSimulationButton.setVisible(!isRunning);
     }
 }

--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/widgets/BlockerWidget.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/widgets/BlockerWidget.java
@@ -2,11 +2,13 @@ package com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets;
 
 import com.groupesan.project.java.scrumsimulator.mainpackage.impl.SprintBlocker;
 import com.groupesan.project.java.scrumsimulator.mainpackage.impl.SprintBlockerSolution;
+import com.groupesan.project.java.scrumsimulator.mainpackage.core.Simulation;
 import com.groupesan.project.java.scrumsimulator.mainpackage.impl.BlockerSolutionsStore;
 import com.groupesan.project.java.scrumsimulator.mainpackage.impl.BlockerStore;
 import com.groupesan.project.java.scrumsimulator.mainpackage.impl.UserStory;
 import com.groupesan.project.java.scrumsimulator.mainpackage.impl.UserStoryStore;
 import com.groupesan.project.java.scrumsimulator.mainpackage.ui.panels.EditBlockerForm;
+import com.groupesan.project.java.scrumsimulator.mainpackage.state.SimulationStateManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -20,10 +22,12 @@ public class BlockerWidget extends JPanel implements BaseComponent {
     private JButton deleteButton;
     private JButton userStoryDropdownButton;
     private JPopupMenu userStoryPopupMenu;
+    private SimulationStateManager simStateManager;
 
 
-    public BlockerWidget(SprintBlocker blocker) {
+    public BlockerWidget(SprintBlocker blocker, SimulationStateManager simStateManager) {
         this.blocker = blocker;
+        this.simStateManager = simStateManager;
         this.init();
         populateUserStories();
         restoreSelectedUserStory();
@@ -72,6 +76,15 @@ public class BlockerWidget extends JPanel implements BaseComponent {
         addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
+                if (simStateManager != null && simStateManager.isRunning()) {
+                    JOptionPane.showMessageDialog(
+                        BlockerWidget.this,
+                        "Cannot edit blocker information while the simulation is running",
+                        "Operation Not Allowed: Simulation Running",
+                        JOptionPane.ERROR_MESSAGE
+                    );
+                    return;
+                }
                 EditBlockerForm form = new EditBlockerForm(blocker);
                 form.setVisible(true);
                 form.addWindowListener(new java.awt.event.WindowAdapter() {
@@ -85,6 +98,15 @@ public class BlockerWidget extends JPanel implements BaseComponent {
 
         deleteButton = new JButton("Delete");
         deleteButton.addActionListener(e -> {
+            if (simStateManager != null && simStateManager.isRunning()) {
+                JOptionPane.showMessageDialog(
+                    BlockerWidget.this,
+                    "Cannot delete blocker while the simulation is running",
+                    "Operation Not Allowed: Simulation Running",
+                    JOptionPane.ERROR_MESSAGE
+                );
+                return;
+            }
             if (blocker.getSolution() != null) {
                 blocker.getSolution().setBlocker(null);
             }
@@ -101,7 +123,19 @@ public class BlockerWidget extends JPanel implements BaseComponent {
         add(deleteButton, gbc);
 
         userStoryDropdownButton = new JButton("Edit User Stories");
-        userStoryDropdownButton.addActionListener(e -> showUserStoryPopupMenu());
+        userStoryDropdownButton.addActionListener(e -> {
+            if (simStateManager != null && simStateManager.isRunning()) {
+                JOptionPane.showMessageDialog(
+                    BlockerWidget.this,
+                    "Cannot edit user stories while the simulation is running",
+                    "Operation Not Allowed: Simulation Running",
+                    JOptionPane.ERROR_MESSAGE
+                );
+                return;
+            }
+            
+            showUserStoryPopupMenu();
+        });
         gbc.gridx = 5;
         gbc.weightx = 0.3;
         add(userStoryDropdownButton, gbc);
@@ -173,6 +207,10 @@ public class BlockerWidget extends JPanel implements BaseComponent {
         } else {
             blocker.removeUserStory(userStory);
         }
+    }
+
+    public void setStateManager(SimulationStateManager simStateManager) {
+        this.simStateManager = simStateManager;
     }
 
     public void populateUserStories() {


### PR DESCRIPTION
## Developer Checklist
- [x] Corresponding User Story/Task on Taiga moved to "Ready For Test"
- [x] Code builds and runs
- [x] Code is formatted properly
- [x] JavaDoc comments are included on essential methods
- [x] Unclear code is commented
- [x] Static analysis checks are passing
- [x] All test cases are passing
- [x] 100% of critical non-UI code is covered by unit tests
- [x] Pipeline ran successfully
- [x] All task requirements are fulfilled
- [x] **Pulled and merged dev before opening a Pull Request**
- [x] If the task is the last task to be completed for a story, all story acceptance criteria must be met

### While the simulation is running, the user (any) cannot edit, delete or assign user stories to a blocker item in the blocker list window.

### Implementation Video

https://github.com/user-attachments/assets/2281f1b5-6a4a-4a50-aadd-a700dfa7a4e4
